### PR TITLE
Fix for babel issues stopping prod build

### DIFF
--- a/frontend/app/.babelrc
+++ b/frontend/app/.babelrc
@@ -1,10 +1,8 @@
 {
   "presets": [
-    "env",
-    "react"
+    "react-app"
   ],
   "plugins": [
-    "transform-class-properties",
     [
       "module-resolver",
       {

--- a/frontend/app/.babelrc
+++ b/frontend/app/.babelrc
@@ -1,9 +1,10 @@
 {
   "presets": [
-    "react",
-    "env"
+    "env",
+    "react"
   ],
   "plugins": [
+    "transform-class-properties",
     [
       "module-resolver",
       {

--- a/frontend/app/.babelrc
+++ b/frontend/app/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": [
     "react",
-    "stage-0"
+    "env"
   ],
   "plugins": [
     [

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -115,6 +115,7 @@
     "@storybook/react": "^3.4.11",
     "@storybook/storybook-deployer": "^2.3.0",
     "babel-plugin-module-resolver": "^3.1.1",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "eslint-config-prettier": "^3.1.0",
     "eslint-plugin-node": "^7.0.1",
     "eslint-plugin-prettier": "^3.0.0",

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -100,10 +100,14 @@
       "mjs"
     ]
   },
-  "babel": {
-    "presets": [
-      "react-app"
-    ]
+  "browserslist": {
+    "targets": {
+      "chrome": "68",
+      "android": "68",
+      "firefox": "17",
+      "ios": "11.4",
+      "safari": "11.1"
+    }
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -100,15 +100,12 @@
       "mjs"
     ]
   },
-  "browserslist": {
-    "targets": {
-      "chrome": "68",
-      "android": "68",
-      "firefox": "17",
-      "ios": "11.4",
-      "safari": "11.1"
-    }
-  },
+  "browserslist": [
+    "last 1 Firefox Version",
+    "last 1 Chrome Version",
+    "last 1 iOS Version",
+    "last 1 Android Version"
+  ],
   "eslintConfig": {
     "extends": "react-app"
   },

--- a/frontend/app/src/styles/main.scss
+++ b/frontend/app/src/styles/main.scss
@@ -1,6 +1,5 @@
 // External Imports
 @import url('https://fonts.googleapis.com/css?family=Zilla+Slab:400,500,700');
-@import '~normalize.css';
 
 // Style Modules
 @import 'vars';


### PR DESCRIPTION
- Remove CSS file from scss because react build scripts complain (Duplicate import in App.js anyway so needed removing).

- Add `babel-preset-env` to .babelrc so that code compiles (I assume this bug was introduced when using a custom config for module-resolve?)

- Add `babel-plugin-transform-class-properties` to .babelrc to fix issues with storybook building