### PR TITLE
Add assignment expiry to the review endpoint

### DIFF
--- a/mresponse/reviews/api/serializers.py
+++ b/mresponse/reviews/api/serializers.py
@@ -26,6 +26,7 @@ class ReviewSerializer(serializers.ModelSerializer):
             'review_text',
             'review_rating',
             'last_modified',
+            'assignment_expires_at',
             'response_url',
             'skip_url',
         )

--- a/mresponse/reviews/models.py
+++ b/mresponse/reviews/models.py
@@ -56,6 +56,13 @@ class Review(models.Model):
             self.android_sdk_version
         )
 
+    @property
+    def assignment_expires_at(self):
+        if self.assigned_to_user_at:
+            return self.assigned_to_user_at + reviews_query.ASSIGNMENT_TIMEOUT
+        return
+
+
     @transaction.atomic()
     def assign_to_user(self, user):
         # If assignment of the other reviews to the user expired, return


### PR DESCRIPTION
This is so we can refresh the endpoint more efficiently from the client. Suggested by @NathHorrigan .