### PR TITLE
Remove API base url

### DIFF
--- a/mresponse/frontend/app/src/redux/util/api-wrapper.js
+++ b/mresponse/frontend/app/src/redux/util/api-wrapper.js
@@ -1,8 +1,7 @@
 import Api from '@utils/api'
-import { BASE_URL } from '@utils/urls'
 
 export const connectApi = (action, ...props) => (dispatch, getState) => {
   const { auth: { token } } = getState()
-  const api = new Api(BASE_URL, token)
+  const api = new Api(token)
   return dispatch(action(api))
 }

--- a/mresponse/frontend/app/src/utils/api.js
+++ b/mresponse/frontend/app/src/utils/api.js
@@ -1,8 +1,7 @@
 import { staticAsset } from '@utils/urls'
 
 export default class Api {
-  constructor (baseUrl, token) {
-    this.baseUrl = baseUrl
+  constructor (token) {
     this.token = token
   }
 
@@ -13,7 +12,7 @@ export default class Api {
     }
     options.headers = headers
 
-    return fetch(`${this.baseUrl}${path}`, options)
+    return fetch(path, options)
   }
 
   async getConfig () {

--- a/mresponse/frontend/app/src/utils/urls.js
+++ b/mresponse/frontend/app/src/utils/urls.js
@@ -1,6 +1,3 @@
-// Config
-export const BASE_URL = process.env.REACT_APP_BASE_URL || 'http://mresponse.local:8000'
-
 // React App Routes
 export const WELCOME_URL = '/'
 export const LOGIN_URL = '/account/login/'


### PR DESCRIPTION
API will always be hosted on same domain as app so we can use relative paths