### PR TITLE
Force MFA for admins

### DIFF
--- a/mresponse/settings/base.py
+++ b/mresponse/settings/base.py
@@ -160,7 +160,7 @@ else:
 # Django authentication backends
 
 AUTHENTICATION_BACKENDS = [
-    'mozilla_django_oidc.auth.OIDCAuthenticationBackend',
+    'mresponse.utils.auth.MFAAuthenticationBackend',
     'django.contrib.auth.backends.ModelBackend'
 ]
 
@@ -493,6 +493,8 @@ if env.get('BASIC_AUTH_ENABLED', 'false').lower().strip() == 'true':
             env['BASIC_AUTH_WHITELISTED_HTTP_HOSTS'].split(',')
         )
 
+if env.get('ENABLE_MFA_ADMIN', 'false').lower().strip() == 'true':
+    MIDDLEWARE.insert(0, 'mresponse.utils.auth.admin_mfa_middleware')
 
 # Django REST Framework settings
 REST_FRAMEWORK = {

--- a/mresponse/utils/auth.py
+++ b/mresponse/utils/auth.py
@@ -1,0 +1,31 @@
+from django.conf import settings
+from django.core.exceptions import PermissionDenied
+
+from mozilla_django_oidc.auth import OIDCAuthenticationBackend
+
+
+class MFAAuthenticationBackend(OIDCAuthenticationBackend):
+    """Add 2fa information in user session"""
+
+    def filter_users_by_claims(self, claims):
+        users = super(MFAAuthenticationBackend, self).filter_users_by_claims(claims)
+        if users.exists():
+            self.request.session['oidc_claims_sub'] = claims['sub']
+        return users
+
+
+def admin_mfa_middleware(get_response):
+    """Force MFA in admin views"""
+
+    def middleware(request):
+        """Check OIDC sub and allow only LDAP"""
+        if request.path.startswith('/admin/') and not settings.DEBUG:
+            oidc_sub = request.session.get('oidc_claims_sub', '')
+            is_admin_mfa = 'ad|Mozilla-LDAP' in oidc_sub
+            if not is_admin_mfa:
+                raise PermissionDenied
+
+        response = get_response(request)
+        return response
+
+    return middleware


### PR DESCRIPTION
* Add OIDC `sub` in user session
* Add middleware that only allows `LDAP` subs for admin paths